### PR TITLE
Add ticket module audit report

### DIFF
--- a/guides/ticket-module-audit.md
+++ b/guides/ticket-module-audit.md
@@ -1,0 +1,48 @@
+# Ticket Module Audit Report
+
+## 1. Completeness Check
+- The ticket creation component does not capture a ticket description or initial message, limiting context when tickets are first logged.
+- Critical priority handling includes a placeholder hotline reference that has not been configured.
+- Several components reference a `resolved` status that does not exist in `App\Enums\TicketStatus`, leading to inconsistent status handling.
+- `TicketPolicy` exists but is not registered, so policy-based authorization is not enforced.
+- Background command for updating `latest_message_at` uses redundant query conditions.
+
+## 2. UI/UX Consistency Check
+- Status badges are manually styled in multiple views, producing inconsistent colors compared to the centralized `TicketColorService`.
+- The create‑ticket form omits a description field and uses an animated loading message that differs from the rest of the application’s tone.
+- Organization and user ticket listings rely on ad‑hoc status logic and colors, causing visual drift from other ticket views.
+
+## 3. Permissions and Role Enforcement
+- Assignment actions rely on the `tickets.update` permission instead of the more granular `tickets.assign` permission defined in the modules configuration.
+- Ticket policy is not mapped in `AuthServiceProvider`, so policy methods like `view`, `update`, or `assign` are never invoked.
+- Attachment access checks only compare department IDs and ignore department group rules, allowing potential cross‑department access.
+
+## 4. Code & File Structure Audit
+- Duplicate `orWhereNull('latest_message_at')` clause in `UpdateLatestMessageAt` command suggests leftover or redundant logic.
+- Admin user view links use a non‑existent route (`tickets.view`) instead of the defined `tickets.show` route.
+- Quick filter options in `ManageTickets` mention only four values in comments but the switch statement handles an additional `my_department_group` case.
+
+## 5. Detailed Issues and Recommendations
+| File Path | Line Number(s) | Issue | Recommended Fix |
+|---|---|---|---|
+| `app/Livewire/CreateTicket.php` | 27‑35 | Ticket creation form lacks description/initial message fields, reducing clarity on ticket context. | Add description and optional initial message fields to the form and view. |
+| `app/Livewire/CreateTicket.php` | 98‑106 | Critical priority note contains `[HOTLINE_NUMBER]` placeholder. | Replace the placeholder with a configurable setting or remove the note. |
+| `app/Livewire/ManageTickets.php` | 45 | Quick‑filter comment omits `my_department_group`, which is handled in code. | Update comment to list all supported filters. |
+| `app/Livewire/ManageTickets.php` | 221‑229 | `assignToMe` checks `tickets.update` instead of `tickets.assign`. | Authorize with `tickets.assign` to respect permission granularity. |
+| `app/Livewire/ViewTicket.php` | 284‑291 | `assignToMe` also uses `tickets.update` permission. | Switch to `tickets.assign` to align with module permissions. |
+| `app/Livewire/ManageTickets.php` | 345‑346 | `changeStatus` handles a `resolved` status not defined in `TicketStatus`. | Align status logic with enum values or add a new enum case. |
+| `app/Livewire/ViewTicket.php` | 335‑336 | Same undefined `resolved` status referenced during status changes. | Update to use an existing status or extend the enum. |
+| `resources/views/livewire/manage-tickets.blade.php` | 287‑288, 372 | UI conditions reference `resolved` status. | Replace with valid status (e.g., `solution_provided`) or add enum support. |
+| `resources/views/livewire/partials/organization/tickets-tab.blade.php` | 30‑35 | Manual status color mapping includes `resolved` and hard‑coded colors. | Use `TicketStatus` enum with `TicketColorService` for consistent styling and valid statuses. |
+| `resources/views/livewire/admin/view-user.blade.php` | 313 | Link uses route name `tickets.view`, which is undefined. | Change to `route('tickets.show', $ticket)`. |
+| `app/Providers/AuthServiceProvider.php` | 21‑25 | `TicketPolicy` not registered. | Map `Ticket::class => TicketPolicy::class` in the policies array. |
+| `app/Http/Controllers/AttachmentController.php` | 109‑112, 129‑131 | Department‑based checks ignore department group rules used elsewhere. | Incorporate department group validation to match ticket access logic. |
+| `app/Console/Commands/UpdateLatestMessageAt.php` | 32‑33 | Redundant `orWhereNull('latest_message_at')` clause. | Remove the duplicate condition. |
+
+## 6. UX Enhancement Suggestions
+- Support richer ticket creation with description and file attachments.
+- Centralize status badge rendering via an enum helper to ensure uniform colors and labels across views.
+- Provide real‑time message/notes updates (e.g., Livewire polling or Pusher) and highlight new entries temporarily.
+- Improve filtering by adding preset filters (e.g., "Recently updated") and saving user preferences.
+- Add clearer status indicators or timelines on ticket detail pages to show progress.
+


### PR DESCRIPTION
## Summary
- add comprehensive ticket module audit report covering completeness, UX, permissions, and code structure

## Testing
- `composer test` *(fails: Failed to open required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689a0429b1148332bf5dd9601ab12062