### PR TITLE
docs: outline phased ticket module rollout

### DIFF
--- a/guides/phase-1-ticket-view.md
+++ b/guides/phase-1-ticket-view.md
@@ -1,0 +1,87 @@
+# Phase 1 – Ticket View Changes
+
+## Discovery Map
+- `app/Livewire/ViewTicket.php`
+  - Note flag defaults and message loading: lines 61–107, 109–116【F:app/Livewire/ViewTicket.php†L61-L116】
+  - Permissions for editing/replying/notes: lines 145–185【F:app/Livewire/ViewTicket.php†L145-L185】
+- `resources/views/livewire/view-ticket.blade.php`
+  - Original description displayed separately: lines 244–258【F:resources/views/livewire/view-ticket.blade.php†L244-L258】
+  - Internal note listing and controls: lines 263–333【F:resources/views/livewire/view-ticket.blade.php†L263-L333】
+  - Conversation stream loop: lines 535–629【F:resources/views/livewire/view-ticket.blade.php†L535-L629】
+- `app/Livewire/CreateTicket.php`
+  - Description stored only on ticket record: lines 25–64, 97–124【F:app/Livewire/CreateTicket.php†L25-L124】
+- `resources/views/livewire/view-organization.blade.php`
+  - “Quick Stats” card placeholder: lines 194–218【F:resources/views/livewire/view-organization.blade.php†L194-L218】
+
+## Required Changes
+1. **Move description to conversation**
+   - Migration: copy any existing `tickets.description` into a `ticket_messages` record and mark the ticket column deprecated.
+   - `app/Livewire/CreateTicket.php`
+     ```diff
+@@ line 97 @@
+-        $ticket = Ticket::create($validated);
++        $ticket = Ticket::create(collect($validated)->except('description')->toArray());
++        TicketMessage::create([
++            'ticket_id' => $ticket->id,
++            'sender_id' => $ticket->client_id,
++            'message' => $validated['description'],
++        ]);
+     ```
+   - `resources/views/livewire/view-ticket.blade.php`
+     ```diff
+@@ line 244–258 @@
+-@if($ticket->description)
+-    … existing description block …
+-@endif
+     ```
+2. **Unified conversation ordering**
+   - `app/Livewire/ViewTicket.php`
+     ```diff
+@@ line 76–107 @@
+-    $this->ticket->setRelation('messages', $ticket->messages()->…->latest('created_at')->get());
++    $messages = $ticket->messages()->select([...])->with('sender','attachments');
++    $publicNotes = $ticket->notes()->where('is_internal', false)->select(['id as note_id','user_id as sender_id','note as message','created_at']) ;
++    $this->conversation = $messages->unionAll($publicNotes)->orderBy('created_at','desc')->get();
+     ```
+   - Replace view loop to iterate over `$conversation` and add branches for note vs reply vs system.
+3. **System events participation**
+   - Ensure status changes/close/reopen create `TicketMessage` entries with `is_system_message = true` in `changeStatus`, `updateTicket`, and `submitClose` methods.
+4. **Note editing and authorization**
+   - Create `app/Policies/TicketNotePolicy.php` with `update`/`delete` rules mirroring `TicketPolicy` view logic.
+   - Register policy in `AuthServiceProvider`.
+   - Update notes loop to show **Edit** button and disabled tooltip when `@cannot('update', $note)`.
+5. **Default notes to internal**
+   - `app/Livewire/ViewTicket.php`: set `$noteInternal = true` (line 61).
+   - Add checkbox helper text clarifying public note behavior.
+6. **Conversation type styles**
+   - Ticket replies: existing neutral style.
+   - Public notes: add left border and “Note” label.
+   - System messages: retain blue treatment; include status-change icon.
+7. **Organization Note card**
+   - `resources/views/livewire/view-ticket.blade.php`: insert card after ticket details and before internal notes.
+   - `resources/views/livewire/view-organization.blade.php`: replace “Quick Stats” with same card content.
+
+## UX Rationale
+- Placing the initial description and system events into the conversation gives a single chronological narrative, reducing cognitive load.
+- Consistent note editing prevents dead‑ends and clarifies permissions.
+- Organization notes surface context without hunting through separate tabs.
+
+## Accessibility Notes
+- Ensure Edit buttons and system message labels expose `aria-label` and follow focus order.
+- Use `role="status"` on system messages so screen readers announce changes.
+- Tooltip for disabled Edit uses `title` and remains visible on keyboard focus.
+
+## Performance Notes
+- Use eager‑loading for `notes.user` and `messages.attachments` to avoid N+1 issues.
+- The union query should select only required columns and apply `orderBy` in SQL to keep pagination light.
+
+## Deprecations / Safe Removals
+- `tickets.description` column – retain for now but mark deprecated; plan removal after backfill.
+- Legacy “Quick Stats” card in organization view.
+
+## Test Checklist
+- Feature: creating a ticket stores initial description as first message.
+- Feature: conversation renders replies, public notes, and system messages in descending order.
+- Policy: unauthorized users cannot edit notes; authorized users can.
+- Livewire: toggling “internal” unchecked pushes note into conversation feed.
+- Feature: Organization note card displays in ticket and organization views.

--- a/guides/phase-2-ticket-manage.md
+++ b/guides/phase-2-ticket-manage.md
@@ -1,0 +1,100 @@
+# Phase 2 – Ticket Manage Listing Improvements
+
+## Discovery Map
+- `app/Livewire/ManageTickets.php`
+  - Query, sorting, and quick filters: lines 399–519【F:app/Livewire/ManageTickets.php†L399-L519】
+  - Priority change handler: lines 280–304【F:app/Livewire/ManageTickets.php†L280-L304】
+- `resources/views/livewire/manage-tickets.blade.php`
+  - Desktop table header and row layout: lines 180–333【F:resources/views/livewire/manage-tickets.blade.php†L180-L333】
+- `app/Models/Ticket.php`
+  - Current `assigned_to` relationship and scope: lines 52–57, 119–125, 191–196【F:app/Models/Ticket.php†L52-L57】【F:app/Models/Ticket.php†L119-L125】【F:app/Models/Ticket.php†L191-L196】
+
+## Required Changes
+1. **Presence icons**
+   - `app/Livewire/ManageTickets.php`
+     ```diff
+@@ line 399 @@
+-    $query = Ticket::query()->with([...])->withCount('messages');
++    $query = Ticket::query()
++        ->with(['organization:id,name', 'department:id,name,department_group_id', 'department.departmentGroup:id,name', 'client:id,name,email', 'owner:id,name'])
++        ->withCount([
++            'notes as internal_note_count' => fn($q) => $q->where('is_internal', true),
++            'attachments'
++        ]);
+     ```
+   - `resources/views/livewire/manage-tickets.blade.php`
+     ```diff
+@@ line 194 @@
+-    <div class="text-xs font-medium text-sky-600 dark:text-sky-400">
+-        #{{ $ticket->ticket_number }}
+-    </div>
++    <div class="flex items-center gap-1 text-xs font-medium text-sky-600 dark:text-sky-400">
++        #{{ $ticket->ticket_number }}
++        @if($ticket->internal_note_count)
++            <x-heroicon-o-document-text class="h-4 w-4" title="This ticket has internal notes" />
++        @endif
++        @if($ticket->attachments_count)
++            <x-heroicon-o-paper-clip class="h-4 w-4" title="This ticket has attachments" />
++        @endif
++    </div>
+     ```
+   - Provide similar icon row for mobile cards.
+2. **Department group & department columns**
+   - `resources/views/livewire/manage-tickets.blade.php` table header: insert columns after “Client”.
+   - Update row layout with `$ticket->department->departmentGroup->name` and `$ticket->department->name`.
+   - Add matching mobile card lines.
+   - `ManageTickets` query: already eager‑loads `department.departmentGroup`; extend sortable/filterable arrays and UI.
+3. **Rename “Assigned to” → “Owner”**
+   - Database: migration to rename `tickets.assigned_to` → `owner_id` and related indexes.
+   - `app/Models/Ticket.php`
+     ```diff
+@@ line 52 @@
+-        'assigned_to',
++        'owner_id',
+@@ line 119 @@
+-        'assigned_to' => 'datetime',
++        'owner_id' => 'datetime', // retains null behaviour
+@@ line 191 @@
+-    public function assigned(): BelongsTo
+-    {
+-        return $this->belongsTo(User::class, 'assigned_to');
+-    }
++    public function owner(): BelongsTo
++    {
++        return $this->belongsTo(User::class, 'owner_id');
++    }
+@@ line 219 @@
+-    public function scopeAssignedTo($query, $userId)
+-    {
+-        return $query->where('assigned_to', $userId);
+-    }
++    public function scopeOwnedBy($query, $userId)
++    {
++        return $query->where('owner_id', $userId);
++    }
+     ```
+   - Replace `assigned`/`assigned_to` references in `ManageTickets`, `ViewTicket`, tests, exports, and language strings with `owner`/`owner_id`.
+
+## UX Rationale
+- Icons quickly communicate hidden metadata without bloating the table.
+- Splitting Department Group and Department clarifies routing of tickets.
+- “Owner” aligns terminology with responsibility; naming consistency reduces cognitive friction.
+
+## Accessibility Notes
+- Icons include descriptive `title` attributes and `sr-only` text for screen readers.
+- Additional columns maintain table header associations with `scope="col"`.
+- Preserve color‑contrast and dark‑mode parity from existing monochrome palette.
+
+## Performance Notes
+- Added `withCount` reduces subqueries for note/attachment presence.
+- Ensure `department` and `departmentGroup` are eager‑loaded to avoid N+1 lookups when rendering new columns.
+
+## Deprecations / Safe Removals
+- Remove `scopeAssignedTo` usage after `owner_id` migration.
+- Update any lingering Blade components or helpers referencing `assigned`.
+
+## Test Checklist
+- Feature: listing displays icons only when internal notes or attachments exist.
+- Feature: table shows Department Group and Department columns with sortable headers.
+- Policy: ensure owner scope respects role‑based filtering.
+- Regression: migrate data from `assigned_to` to `owner_id` without loss; rollback verifies reverse migration.

--- a/guides/phase-3-ticket-rules-and-settings.md
+++ b/guides/phase-3-ticket-rules-and-settings.md
@@ -1,0 +1,77 @@
+# Phase 3 – Ticket Rules and Settings
+
+## Discovery Map
+- `app/Livewire/ManageTickets.php`
+  - Priority change handler lacks role guards: lines 280–304【F:app/Livewire/ManageTickets.php†L280-L304】
+- `app/Livewire/ViewTicket.php`
+  - Priority/status updates: lines 217–276, 312–378【F:app/Livewire/ViewTicket.php†L217-L276】【F:app/Livewire/ViewTicket.php†L312-L378】
+- `app/Models/Ticket.php`
+  - `priority` and `status` fields: lines 23–53【F:app/Models/Ticket.php†L23-L53】
+- `app/Models/Setting.php`
+  - Generic key/value API for application settings: entire file【F:app/Models/Setting.php†L1-L120】
+
+## Required Changes
+1. **One‑way priority escalation**
+   - Add `escalatePriority` gate in `TicketPolicy` ensuring only support/admin can raise above current level.
+   - `ManageTickets::changePriority` and `ViewTicket::updateTicket`
+     ```diff
+@@ line 284 ManageTickets.php @@
+-    $ticket->update(['priority' => $priority]);
++    if(auth()->user()->hasRole('client') && TicketPriority::compare($priority, $ticket->priority) > 0) {
++        session()->flash('error', 'Clients cannot escalate priority.');
++        return;
++    }
++    $ticket->update(['priority' => $priority]);
++    if(TicketPriority::compare($priority, $ticket->priority) > 0) {
++        ActivityLog::record('ticket.priority_escalated', $ticket->id);
++    }
+     ```
+   - Add confirmation dialog in UI for support/admin before escalating.
+2. **Reopen window setting**
+   - Migration & seed: insert setting key `tickets.reopen_window_days` default `3`.
+   - `ViewTicket::changeStatus`
+     ```diff
+@@ line 327 @@
+-    $wasTicketClosed = $this->ticket->status === 'closed';
+-    $isTicketBeingReopened = $wasTicketClosed && $status !== 'closed';
++    $wasTicketClosed = $this->ticket->status === 'closed';
++    $reopenLimit = Setting::get('tickets.reopen_window_days', 3);
++    $isWithinWindow = $this->ticket->closed_at && now()->diffInDays($this->ticket->closed_at) <= $reopenLimit;
++    $isTicketBeingReopened = $wasTicketClosed && $status !== 'closed' && $isWithinWindow;
++    if($wasTicketClosed && !$isWithinWindow && auth()->user()->hasRole('client')) {
++        session()->flash('error', 'Ticket closed more than ' . $reopenLimit . ' days ago. Please create a new ticket.');
++        return redirect()->route('tickets.create', ['subject' => 'Re: ' . $this->ticket->ticket_number]);
++    }
+     ```
+   - Document new setting in settings guide: key `tickets.reopen_window_days`, integer, validated ≥1.
+3. **Audit log entries**
+   - `ActivityLog` model: add static `record` helper; log priority escalations and reopen confirmations.
+4. **Client escalation denial message**
+   - In priority change methods, return validation message when blocked.
+   - Provide “Are you sure?” dialog for support/admin escalations.
+5. **Server‑side policy enforcement**
+   - Extend `TicketPolicy::update` to guard against client escalations and reopen attempts beyond window.
+   - Smoke tests verifying policy denies direct HTTP attempts.
+
+## UX Rationale
+- Clients receive immediate, contextual feedback and a clear path to open a new ticket when limits apply.
+- Confirmation dialogs prevent accidental escalations by staff.
+
+## Accessibility Notes
+- Confirmation modals use focus traps and `aria-modal="true"`.
+- Error messages are announced via Livewire `wire:loading.attr="aria-busy"` on forms.
+
+## Performance Notes
+- Setting lookup uses cached `Setting::get` to avoid repeated queries.
+- Priority comparisons rely on enum helpers to avoid string comparisons.
+
+## Deprecations / Safe Removals
+- Remove any direct `status` or `priority` mutations bypassing policy checks in legacy scripts.
+- Mark old reopen logic for deletion once setting is enforced.
+
+## Test Checklist
+- Feature: client cannot raise priority above current value after creation.
+- Feature: support/admin escalation triggers confirmation modal and audit log.
+- Feature: client reopening after window redirects to new ticket creation with subject prefilled.
+- Policy: direct API calls respecting `tickets.reopen_window_days` and escalation rules.
+- Setting: failing validation for negative or non‑integer window values.

--- a/guides/phase-4-multi-org-clients.md
+++ b/guides/phase-4-multi-org-clients.md
@@ -1,0 +1,93 @@
+# Phase 4 – Multi‑Organization Clients
+
+## Discovery Map
+- `app/Models/User.php`
+  - Single `organization_id` column and relationship: lines 51–52, 102–105, 113–120【F:app/Models/User.php†L51-L52】【F:app/Models/User.php†L102-L105】【F:app/Models/User.php†L113-L120】
+- `app/Models/Organization.php`
+  - `users()` hasMany assumption: lines 69–72【F:app/Models/Organization.php†L69-L72】
+- `app/Livewire/CreateTicket.php`
+  - Organization auto‑selection for clients: lines 97–124【F:app/Livewire/CreateTicket.php†L97-L124】
+- `app/Livewire/ManageTickets.php`
+  - Role‑based org filters rely on `user->organization_id`: lines 399–465【F:app/Livewire/ManageTickets.php†L399-L465】
+- `routes/web.php`
+  - Ticket routes guarded by `can:tickets.read` only: lines 66–90【F:routes/web.php†L66-L90】
+
+## Required Changes
+1. **Schema & Relationships**
+   - Migration: create `organization_user` pivot (`user_id`, `organization_id`, timestamps).
+   - Backfill: insert existing `users.organization_id` into pivot then drop column after verification; rollback re‑adds column.
+   - `User.php`
+     ```diff
+@@ line 51 @@
+-        'department_id',
+-        'organization_id',
++        'department_id',
+     ];
+@@ line 102 @@
+-    public function organization(): BelongsTo
+-    {
+-        return $this->belongsTo(Organization::class);
+-    }
++    public function organizations(): BelongsToMany
++    {
++        return $this->belongsToMany(Organization::class)->withTimestamps();
++    }
+@@ line 113 @@
+-    public function tickets()
+-    {
+-        return $this->hasMany(Ticket::class, 'client_id');
+-    }
++    public function tickets()
++    {
++        return $this->hasMany(Ticket::class, 'client_id');
++    }
+     ```
+   - `Organization.php`
+     ```diff
+@@ line 69 @@
+-    public function users(): HasMany
+-    {
+-        return $this->hasMany(User::class, 'organization_id');
+-    }
++    public function users(): BelongsToMany
++    {
++        return $this->belongsToMany(User::class)->withTimestamps();
++    }
+     ```
+2. **Policy & Query Updates**
+   - Update `TicketPolicy::view`/`update` to check `user->organizations->contains($ticket->organization_id)` for clients.
+   - Adjust `ManageTickets` filters to `whereHas('organizations', fn($q)=>$q->where('id',$orgId))` for clients.
+   - `CreateTicket` mount: if client has multiple organizations, present selector; otherwise auto‑select first.
+3. **UI Adjustments**
+   - Ticket creation form: show organization dropdown for eligible clients; default to first allowed organization.
+   - Listing filters: organization filter uses `auth()->user()->organizations` for clients.
+   - Ensure Livewire components use `auth()->user()->organizations()->pluck('id')` for scoping.
+4. **Spatie Permissions & Middleware**
+   - Introduce `organization` scope middleware verifying `request()->route('organization')` is within user’s allowed set.
+   - Update route groups and Livewire `can` checks to incorporate new pivot checks.
+5. **Seeds & Fixtures**
+   - Extend `ClientSampleDataSeeder` to attach each test client to one or more organizations via pivot.
+   - Provide artisan command to backfill existing production users.
+
+## UX Rationale
+- Corporate clients can switch between organizations without separate accounts, streamlining support requests.
+- Single‑org users retain existing behaviour with auto‑selected organization.
+
+## Accessibility Notes
+- Organization selector is keyboard navigable and labelled; announce changes via `aria-live`.
+- When only one organization exists, render as static text to reduce tab stops.
+
+## Performance Notes
+- Index `organization_user.user_id` and `.organization_id` for fast scoping.
+- Prefetch allowed organization IDs in session to avoid repeated pivot queries.
+
+## Deprecations / Safe Removals
+- Drop `users.organization_id` after backfill.
+- Remove helper methods assuming singular organization, e.g., `User::organization()` accessor.
+
+## Test Checklist
+- Feature: multi‑org client can create ticket choosing any allowed organization; single‑org client auto‑selected.
+- Feature: ticket listings and filters show only scoped organizations for clients.
+- Policy: client cannot access tickets outside pivot memberships.
+- Regression: admin/support unaffected; existing API tokens continue to function.
+- Migration: backfill and rollback scripts verified on sample data.


### PR DESCRIPTION
## Summary
- add phase guides for ticket view tweaks, manage listing enhancements, rules & settings, and multi-org access
- map current implementation files and propose minimal diffs, UX/accessibility/performance notes, and test plans

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b237ed4f88332865f19a03427ba37