### PR TITLE
Refactor contract schema and organization validation

### DIFF
--- a/app/Http/Controllers/OrganizationContractController.php
+++ b/app/Http/Controllers/OrganizationContractController.php
@@ -31,10 +31,13 @@ class OrganizationContractController extends Controller
             'org_id'        => 'required|exists:organizations,id',
             'department_id' => 'required|exists:departments,id',
             'is_hardware'   => 'boolean',
+            'is_oracle'     => 'boolean',
+            'csi_number'    => 'required_if:is_oracle,true|nullable|string',
             'csi_remarks'   => 'nullable|string',
             'start_date'    => 'required|date',
             'end_date'      => 'nullable|date|after_or_equal:start_date',
             'status'        => 'required|string|in:active,expired,terminated,onhold',
+            'notes'         => 'nullable|string',
         ]);
 
 
@@ -68,10 +71,13 @@ class OrganizationContractController extends Controller
             'org_id'        => 'required|exists:organizations,id',
             'department_id' => 'required|exists:departments,id',
             'is_hardware'   => 'boolean',
+            'is_oracle'     => 'boolean',
+            'csi_number'    => 'required_if:is_oracle,true|nullable|string',
             'csi_remarks'   => 'nullable|string',
             'start_date'    => 'required|date',
             'end_date'      => 'nullable|date|after_or_equal:start_date',
             'status'        => 'required|string|in:active,expired,terminated,onhold',
+            'notes'         => 'nullable|string',
         ]);
 
         $contract->update($data);

--- a/app/Livewire/ManageContracts.php
+++ b/app/Livewire/ManageContracts.php
@@ -24,13 +24,13 @@ class ManageContracts extends Component
         'type' => 'support',
         'status' => 'active',
         'includes_hardware' => false,
-        'contract_value' => '',
-        'currency' => 'USD',
+        'is_oracle' => false,
+        'csi_number' => '',
         'start_date' => '',
         'end_date' => '',
         'renewal_months' => '',
         'csi_remarks' => '',
-        'terms_conditions' => '',
+        'notes' => '',
     ];
 
     protected $rules = [
@@ -39,13 +39,13 @@ class ManageContracts extends Component
         'form.type' => 'required|in:support,hardware,software,consulting,maintenance',
         'form.status' => 'required|in:draft,active,expired,terminated,renewed',
         'form.includes_hardware' => 'boolean',
-        'form.contract_value' => 'nullable|numeric|min:0',
-        'form.currency' => 'required|string|size:3',
+        'form.is_oracle' => 'boolean',
+        'form.csi_number' => 'required_if:form.is_oracle,true|nullable|string|max:255',
         'form.start_date' => 'required|date',
         'form.end_date' => 'nullable|date|after_or_equal:form.start_date',
         'form.renewal_months' => 'nullable|integer|min:1|max:120',
         'form.csi_remarks' => 'nullable|string',
-        'form.terms_conditions' => 'nullable|string',
+        'form.notes' => 'nullable|string',
     ];
 
     public function mount(Organization $organization)
@@ -78,13 +78,13 @@ class ManageContracts extends Component
             'type' => 'support',
             'status' => 'active',
             'includes_hardware' => false,
-            'contract_value' => null,
-            'currency' => 'USD',
+            'is_oracle' => false,
+            'csi_number' => null,
             'start_date' => now()->format('Y-m-d'),
             'end_date' => null,
             'renewal_months' => null,
             'csi_remarks' => null,
-            'terms_conditions' => null,
+            'notes' => null,
         ];
         
         $this->showForm = true;
@@ -100,13 +100,13 @@ class ManageContracts extends Component
             'type' => $this->editingContract->type,
             'status' => $this->editingContract->status,
             'includes_hardware' => $this->editingContract->includes_hardware,
-            'contract_value' => $this->editingContract->contract_value,
-            'currency' => $this->editingContract->currency,
+            'is_oracle' => $this->editingContract->is_oracle,
+            'csi_number' => $this->editingContract->csi_number,
             'start_date' => $this->editingContract->start_date?->format('Y-m-d') ?? '',
             'end_date' => $this->editingContract->end_date?->format('Y-m-d') ?? '',
             'renewal_months' => $this->editingContract->renewal_months,
             'csi_remarks' => $this->editingContract->csi_remarks,
-            'terms_conditions' => $this->editingContract->terms_conditions,
+            'notes' => $this->editingContract->notes,
         ];
 
         $this->showForm = true;
@@ -128,7 +128,7 @@ class ManageContracts extends Component
         $data['organization_id'] = $this->organization->id;
 
         // Convert empty strings to null for nullable numeric fields
-        $nullableFields = ['contract_value', 'renewal_months'];
+        $nullableFields = ['renewal_months'];
         foreach ($nullableFields as $field) {
             if (empty($data[$field]) || $data[$field] === '') {
                 $data[$field] = null;
@@ -136,7 +136,7 @@ class ManageContracts extends Component
         }
 
         // Convert empty strings to null for nullable text fields
-        $nullableTextFields = ['end_date', 'csi_remarks', 'terms_conditions'];
+        $nullableTextFields = ['end_date', 'csi_remarks', 'csi_number', 'notes'];
         foreach ($nullableTextFields as $field) {
             if (empty($data[$field]) || $data[$field] === '') {
                 $data[$field] = null;

--- a/app/Livewire/ManageOrganizations.php
+++ b/app/Livewire/ManageOrganizations.php
@@ -130,9 +130,16 @@ class ManageOrganizations extends Component
 
         $this->validate($rules, $this->getOrganizationValidationMessages());
 
+        $data = $this->form;
+        foreach (['company', 'tin_no'] as $nullableField) {
+            if ($data[$nullableField] === '') {
+                $data[$nullableField] = null;
+            }
+        }
+
         $organization = Organization::updateOrCreate(
-            ['id' => $this->form['id']],
-            $this->form
+            ['id' => $data['id']],
+            $data
         );
 
         session()->flash('message', $this->form['id'] ? 'Organization updated successfully.' : 'Organization created successfully.');

--- a/app/Livewire/OrganizationContractForm.php
+++ b/app/Livewire/OrganizationContractForm.php
@@ -20,13 +20,13 @@ class OrganizationContractForm extends Component
         'type' => 'support',
         'status' => 'active',
         'includes_hardware' => false,
-        'contract_value' => '',
-        'currency' => 'USD',
+        'is_oracle' => false,
+        'csi_number' => '',
         'start_date' => '',
         'end_date' => '',
         'renewal_months' => '',
         'csi_remarks' => '',
-        'terms_conditions' => '',
+        'notes' => '',
     ];
 
     protected $rules = [
@@ -35,13 +35,13 @@ class OrganizationContractForm extends Component
         'form.type' => 'required|in:support,hardware,software,consulting,maintenance',
         'form.status' => 'required|in:draft,active,expired,terminated,renewed',
         'form.includes_hardware' => 'boolean',
-        'form.contract_value' => 'nullable|numeric|min:0',
-        'form.currency' => 'required|string|size:3',
+        'form.is_oracle' => 'boolean',
+        'form.csi_number' => 'required_if:form.is_oracle,true|nullable|string|max:255',
         'form.start_date' => 'required|date',
         'form.end_date' => 'nullable|date|after_or_equal:form.start_date',
         'form.renewal_months' => 'nullable|integer|min:1|max:120',
         'form.csi_remarks' => 'nullable|string',
-        'form.terms_conditions' => 'nullable|string',
+        'form.notes' => 'nullable|string',
     ];
 
     protected $messages = [
@@ -69,13 +69,13 @@ class OrganizationContractForm extends Component
             'type' => 'support',
             'status' => 'active',
             'includes_hardware' => false,
-            'contract_value' => null,
-            'currency' => 'USD',
+            'is_oracle' => false,
+            'csi_number' => null,
             'start_date' => now()->format('Y-m-d'),
             'end_date' => null,
             'renewal_months' => null,
             'csi_remarks' => null,
-            'terms_conditions' => null,
+            'notes' => null,
         ];
     }
 
@@ -103,13 +103,13 @@ class OrganizationContractForm extends Component
             'type' => $this->contract->type,
             'status' => $this->contract->status,
             'includes_hardware' => $this->contract->includes_hardware,
-            'contract_value' => $this->contract->contract_value,
-            'currency' => $this->contract->currency,
+            'is_oracle' => $this->contract->is_oracle,
+            'csi_number' => $this->contract->csi_number,
             'start_date' => $this->contract->start_date?->format('Y-m-d') ?? '',
             'end_date' => $this->contract->end_date?->format('Y-m-d') ?? '',
             'renewal_months' => $this->contract->renewal_months,
             'csi_remarks' => $this->contract->csi_remarks,
-            'terms_conditions' => $this->contract->terms_conditions,
+            'notes' => $this->contract->notes,
         ];
     }
 
@@ -129,7 +129,7 @@ class OrganizationContractForm extends Component
         $data['organization_id'] = $this->organization->id;
 
         // Convert empty strings to null for nullable numeric fields
-        $nullableFields = ['contract_value', 'renewal_months'];
+        $nullableFields = ['renewal_months'];
         foreach ($nullableFields as $field) {
             if (empty($data[$field]) || $data[$field] === '') {
                 $data[$field] = null;
@@ -137,7 +137,7 @@ class OrganizationContractForm extends Component
         }
 
         // Convert empty strings to null for nullable text fields
-        $nullableTextFields = ['end_date', 'csi_remarks', 'terms_conditions'];
+        $nullableTextFields = ['end_date', 'csi_remarks', 'csi_number', 'notes'];
         foreach ($nullableTextFields as $field) {
             if (empty($data[$field]) || $data[$field] === '') {
                 $data[$field] = null;

--- a/app/Livewire/ViewOrganization.php
+++ b/app/Livewire/ViewOrganization.php
@@ -113,7 +113,14 @@ class ViewOrganization extends Component
         $rules = $this->getOrganizationValidationRulesWithExclusion($this->organization->id);
         $validated = $this->validate($rules, $this->getOrganizationValidationMessages());
 
-        $this->organization->update($validated['form']);
+        $data = $validated['form'];
+        foreach (['company', 'tin_no'] as $nullableField) {
+            if ($data[$nullableField] === '') {
+                $data[$nullableField] = null;
+            }
+        }
+
+        $this->organization->update($data);
         $this->organization->refresh();
 
         $this->editMode = false;

--- a/app/Livewire/ViewTicket.php
+++ b/app/Livewire/ViewTicket.php
@@ -57,7 +57,7 @@ class ViewTicket extends Component
         $this->ticket = $ticket->load([
             'organization:id,name,notes',
             'organization.contracts' => function($query) use ($ticket) {
-                $query->select(['id', 'organization_id', 'department_id', 'contract_number', 'type', 'status', 'start_date', 'end_date', 'contract_value', 'currency'])
+                $query->select(['id', 'organization_id', 'department_id', 'contract_number', 'type', 'status', 'start_date', 'end_date'])
                       ->where('department_id', $ticket->department_id)
                       ->where('status', 'active')
                       ->orderBy('start_date', 'desc')

--- a/app/Models/OrganizationContract.php
+++ b/app/Models/OrganizationContract.php
@@ -19,13 +19,13 @@ class OrganizationContract extends Model
         'type',
         'status',
         'includes_hardware',
-        'contract_value',
-        'currency',
+        'is_oracle',
+        'csi_number',
         'start_date',
         'end_date',
         'renewal_months',
         'csi_remarks',
-        'terms_conditions',
+        'notes',
         'service_levels',
     ];
 
@@ -33,7 +33,7 @@ class OrganizationContract extends Model
         'start_date' => 'date',
         'end_date' => 'date',
         'includes_hardware' => 'boolean',
-        'contract_value' => 'decimal:2',
+        'is_oracle' => 'boolean',
         'service_levels' => 'array',
     ];
 

--- a/app/Traits/ValidatesOrganizations.php
+++ b/app/Traits/ValidatesOrganizations.php
@@ -13,9 +13,9 @@ trait ValidatesOrganizations
     {
         return [
             'form.name' => 'required|string|max:255',
-            'form.company' => 'required|string|max:255',
+            'form.company' => 'nullable|string|max:255',
             'form.company_contact' => 'required|string|max:255',
-            'form.tin_no' => 'required|string|max:255|unique:organizations,tin_no',
+            'form.tin_no' => 'nullable|string|max:255|unique:organizations,tin_no',
             'form.email' => 'required|email|unique:organizations,email',
             'form.phone' => 'nullable|string|max:20',
             'form.is_active' => 'boolean',
@@ -35,7 +35,7 @@ trait ValidatesOrganizations
         $rules = $this->getOrganizationValidationRules();
         
         if ($excludeId) {
-            $rules['form.tin_no'] = 'required|string|max:255|unique:organizations,tin_no,' . $excludeId;
+            $rules['form.tin_no'] = 'nullable|string|max:255|unique:organizations,tin_no,' . $excludeId;
             $rules['form.email'] = 'required|email|unique:organizations,email,' . $excludeId;
         }
         
@@ -51,9 +51,7 @@ trait ValidatesOrganizations
     {
         return [
             'form.name.required' => 'Organization name is required',
-            'form.company.required' => 'Company name is required',
             'form.company_contact.required' => 'Company contact is required',
-            'form.tin_no.required' => 'TIN number is required',
             'form.tin_no.unique' => 'This TIN number is already in use',
             'form.email.required' => 'Email is required',
             'form.email.email' => 'Please enter a valid email address',

--- a/database/migrations/2025_01_01_000009_create_organization_contracts_table.php
+++ b/database/migrations/2025_01_01_000009_create_organization_contracts_table.php
@@ -31,15 +31,15 @@ return new class extends Migration
                   ->index();
             
             $table->boolean('includes_hardware')->default(false);
-            $table->decimal('contract_value', 10, 2)->nullable(); // Contract monetary value
-            $table->string('currency', 3)->default('USD'); // Currency code
+            $table->boolean('is_oracle')->default(false); // Indicates Oracle contract
+            $table->string('csi_number')->nullable(); // Oracle CSI number
             
             $table->date('start_date');
             $table->date('end_date')->nullable();
             $table->integer('renewal_months')->nullable(); // Auto-renewal period
             
             $table->text('csi_remarks')->nullable(); // Customer Service Index remarks
-            $table->text('terms_conditions')->nullable(); // Contract terms
+            $table->text('notes')->nullable(); // Contract notes
             $table->json('service_levels')->nullable(); // SLA definitions
             
             $table->timestamps();

--- a/database/seeders/ClientSampleDataSeeder.php
+++ b/database/seeders/ClientSampleDataSeeder.php
@@ -278,9 +278,8 @@ class ClientSampleDataSeeder extends Seeder
                     'contract_number' => 'CNT-' . strtoupper(substr($organization->name, 0, 3)) . '-' . date('Y') . '-' . str_pad(rand(1, 999), 3, '0', STR_PAD_LEFT),
                     'start_date' => $contractData['start_date'],
                     'end_date' => $contractData['end_date'],
-                    'contract_value' => $contractData['value'],
                     'status' => $contractData['status'],
-                    'terms_conditions' => $contractData['description']
+                    'notes' => $contractData['description']
                 ]);
                 
                 $this->command->info("✓ Created contract: {$contractData['service_type']} for {$organization->name}");

--- a/resources/views/components/tickets/details.blade.php
+++ b/resources/views/components/tickets/details.blade.php
@@ -137,7 +137,7 @@
                                 <div class="mt-1 text-sm text-neutral-800 dark:text-neutral-200">
                                     <div>{{ $this->activeContract->contract_number }}</div>
                                     <div class="text-neutral-600 dark:text-neutral-400">
-                                        {{ $this->activeContract->type }} - {{ $this->activeContract->currency }} {{ number_format($this->activeContract->contract_value) }}
+                                        {{ $this->activeContract->type }}
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/livewire/manage-contracts.blade.php
+++ b/resources/views/livewire/manage-contracts.blade.php
@@ -120,41 +120,6 @@
                             </div>
                         </div>
 
-                        {{-- Contract Value & Currency --}}
-                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                            <div class="md:col-span-2">
-                                <label for="contract_value" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
-                                    Contract Value
-                                </label>
-                                <input type="number" 
-                                       wire:model="form.contract_value" 
-                                       id="contract_value"
-                                       step="0.01"
-                                       min="0"
-                                       placeholder="0.00"
-                                       class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
-                                @error('form.contract_value') 
-                                    <span class="text-red-500 text-xs mt-1">{{ $message }}</span> 
-                                @enderror
-                            </div>
-
-                            <div>
-                                <label for="currency" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
-                                    Currency
-                                </label>
-                                <select wire:model="form.currency" 
-                                        id="currency"
-                                        class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
-                                    <option value="USD">USD</option>
-                                    <option value="EUR">EUR</option>
-                                    <option value="MVR">MVR</option>
-                                </select>
-                                @error('form.currency') 
-                                    <span class="text-red-500 text-xs mt-1">{{ $message }}</span> 
-                                @enderror
-                            </div>
-                        </div>
-
                         {{-- Dates --}}
                         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                             <div>
@@ -202,8 +167,8 @@
 
                         {{-- Hardware Inclusion --}}
                         <div class="flex items-center">
-                            <input type="checkbox" 
-                                   wire:model="form.includes_hardware" 
+                            <input type="checkbox"
+                                   wire:model="form.includes_hardware"
                                    id="includes_hardware"
                                    class="h-4 w-4 text-sky-600 focus:ring-sky-500 border-neutral-300 rounded">
                             <label for="includes_hardware" class="ml-2 block text-sm text-neutral-700 dark:text-neutral-300">
@@ -211,12 +176,39 @@
                             </label>
                         </div>
 
+                        {{-- Oracle Details --}}
+                        <div class="mt-4">
+                            <div class="flex items-center">
+                                <input type="checkbox"
+                                       wire:model="form.is_oracle"
+                                       id="is_oracle"
+                                       class="h-4 w-4 text-sky-600 focus:ring-sky-500 border-neutral-300 rounded">
+                                <label for="is_oracle" class="ml-2 block text-sm text-neutral-700 dark:text-neutral-300">
+                                    Oracle Contract
+                                </label>
+                            </div>
+                            @if($form['is_oracle'])
+                                <div class="mt-2">
+                                    <label for="csi_number" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                                        CSI Number *
+                                    </label>
+                                    <input type="text"
+                                           wire:model="form.csi_number"
+                                           id="csi_number"
+                                           class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
+                                    @error('form.csi_number')
+                                        <span class="text-red-500 text-xs mt-1">{{ $message }}</span>
+                                    @enderror
+                                </div>
+                            @endif
+                        </div>
+
                         {{-- CSI Remarks --}}
                         <div>
                             <label for="csi_remarks" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                                 CSI Remarks
                             </label>
-                            <textarea wire:model="form.csi_remarks" 
+                            <textarea wire:model="form.csi_remarks"
                                       id="csi_remarks"
                                       rows="3"
                                       class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100"
@@ -226,18 +218,18 @@
                             @enderror
                         </div>
 
-                        {{-- Terms & Conditions --}}
+                        {{-- Notes --}}
                         <div>
-                            <label for="terms_conditions" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
-                                Terms & Conditions
+                            <label for="notes" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                                Notes
                             </label>
-                            <textarea wire:model="form.terms_conditions" 
-                                      id="terms_conditions"
+                            <textarea wire:model="form.notes"
+                                      id="notes"
                                       rows="4"
                                       class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100"
-                                      placeholder="Contract terms and conditions..."></textarea>
-                            @error('form.terms_conditions') 
-                                <span class="text-red-500 text-xs mt-1">{{ $message }}</span> 
+                                      placeholder="Additional notes..."></textarea>
+                            @error('form.notes')
+                                <span class="text-red-500 text-xs mt-1">{{ $message }}</span>
                             @enderror
                         </div>
 
@@ -288,13 +280,6 @@
                                     <x-heroicon-o-tag class="h-4 w-4" />
                                     <span>{{ ucfirst($contract->type) }}</span>
                                 </div>
-                                
-                                @if($contract->contract_value)
-                                <div class="flex items-center gap-2">
-                                    <x-heroicon-o-currency-dollar class="h-4 w-4" />
-                                    <span>{{ $contract->currency }} {{ number_format($contract->contract_value, 0) }}</span>
-                                </div>
-                                @endif
                                 
                                 <div class="flex items-center gap-2">
                                     <x-heroicon-o-calendar class="h-4 w-4" />

--- a/resources/views/livewire/manage-organizations.blade.php
+++ b/resources/views/livewire/manage-organizations.blade.php
@@ -61,27 +61,24 @@
                     @endforeach
 
                     <div class="form-field-stagger">
-                        <label class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">Subscription Status</label>
-                        <select wire:model.defer="form.subscription_status"
-                            class="w-full px-4 py-2 mt-1 bg-white/60 dark:bg-neutral-800/60 border border-neutral-300 dark:border-neutral-700 
-                                   rounded-md text-sm text-neutral-800 dark:text-neutral-100 focus:ring-2 focus:ring-sky-400 focus:border-transparent outline-none transition-all duration-200">
-                            <option value="trial">Trial</option>
-                            <option value="active">Active</option>
-                            <option value="suspended">Suspended</option>
-                            <option value="cancelled">Cancelled</option>
-                        </select>
+                        <label class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">Subscription & Status</label>
+                        <div class="flex items-center gap-4">
+                            <select wire:model.defer="form.subscription_status"
+                                class="w-full px-4 py-2 bg-white/60 dark:bg-neutral-800/60 border border-neutral-300 dark:border-neutral-700 rounded-md text-sm text-neutral-800 dark:text-neutral-100 focus:ring-2 focus:ring-sky-400 focus:border-transparent outline-none transition-all duration-200">
+                                <option value="trial">Trial</option>
+                                <option value="active">Active</option>
+                                <option value="suspended">Suspended</option>
+                                <option value="cancelled">Cancelled</option>
+                            </select>
+                            <label class="inline-flex items-center">
+                                <input type="checkbox" wire:model.defer="form.is_active"
+                                    class="h-5 w-5 text-sky-600 focus:ring-sky-500 border-neutral-300 rounded">
+                                <span class="ml-2 text-sm text-neutral-800 dark:text-neutral-200">Active</span>
+                            </label>
+                        </div>
                         @error("form.subscription_status")
                             <p class="text-sm text-red-600 mt-1 animate-pulse">{{ $message }}</p>
                         @enderror
-                    </div>
-
-                    <div class="form-field-stagger">
-                        <label class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">Active</label>
-                        <label class="inline-flex items-center">
-                            <input type="checkbox" wire:model.defer="form.is_active"
-                                class="rounded border-neutral-300 text-sky-600 shadow-sm focus:ring-sky-500 transition-all duration-200">
-                            <span class="ml-2 text-sm text-neutral-800 dark:text-neutral-200">Yes</span>
-                        </label>
                     </div>
                 </div>
 

--- a/resources/views/livewire/organization-contract-form.blade.php
+++ b/resources/views/livewire/organization-contract-form.blade.php
@@ -81,41 +81,6 @@
             </div>
         </div>
 
-        {{-- Contract Value & Currency --}}
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div class="md:col-span-2">
-                <label for="contract_value" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
-                    Contract Value
-                </label>
-                <input type="number" 
-                       wire:model="form.contract_value" 
-                       id="contract_value"
-                       step="0.01"
-                       min="0"
-                       placeholder="0.00"
-                       class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
-                @error('form.contract_value') 
-                    <span class="text-red-500 text-xs mt-1">{{ $message }}</span> 
-                @enderror
-            </div>
-
-            <div>
-                <label for="currency" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
-                    Currency
-                </label>
-                <select wire:model="form.currency" 
-                        id="currency"
-                        class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
-                    <option value="USD">USD</option>
-                    <option value="EUR">EUR</option>
-                    <option value="MVR">MVR</option>
-                </select>
-                @error('form.currency') 
-                    <span class="text-red-500 text-xs mt-1">{{ $message }}</span> 
-                @enderror
-            </div>
-        </div>
-
         {{-- Dates --}}
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
@@ -163,8 +128,8 @@
 
         {{-- Hardware Inclusion --}}
         <div class="flex items-center">
-            <input type="checkbox" 
-                   wire:model="form.includes_hardware" 
+            <input type="checkbox"
+                   wire:model="form.includes_hardware"
                    id="includes_hardware"
                    class="h-4 w-4 text-sky-600 focus:ring-sky-500 border-neutral-300 rounded">
             <label for="includes_hardware" class="ml-2 block text-sm text-neutral-700 dark:text-neutral-300">
@@ -172,12 +137,39 @@
             </label>
         </div>
 
+        {{-- Oracle Details --}}
+        <div class="mt-4">
+            <div class="flex items-center">
+                <input type="checkbox"
+                       wire:model="form.is_oracle"
+                       id="is_oracle"
+                       class="h-4 w-4 text-sky-600 focus:ring-sky-500 border-neutral-300 rounded">
+                <label for="is_oracle" class="ml-2 block text-sm text-neutral-700 dark:text-neutral-300">
+                    Oracle Contract
+                </label>
+            </div>
+            @if($form['is_oracle'])
+                <div class="mt-2">
+                    <label for="csi_number" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                        CSI Number *
+                    </label>
+                    <input type="text"
+                           wire:model="form.csi_number"
+                           id="csi_number"
+                           class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
+                    @error('form.csi_number')
+                        <span class="text-red-500 text-xs mt-1">{{ $message }}</span>
+                    @enderror
+                </div>
+            @endif
+        </div>
+
         {{-- CSI Remarks --}}
         <div>
             <label for="csi_remarks" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
                 CSI Remarks
             </label>
-            <textarea wire:model="form.csi_remarks" 
+            <textarea wire:model="form.csi_remarks"
                       id="csi_remarks"
                       rows="3"
                       class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100"
@@ -187,18 +179,18 @@
             @enderror
         </div>
 
-        {{-- Terms & Conditions --}}
+        {{-- Notes --}}
         <div>
-            <label for="terms_conditions" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
-                Terms & Conditions
+            <label for="notes" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                Notes
             </label>
-            <textarea wire:model="form.terms_conditions" 
-                      id="terms_conditions"
+            <textarea wire:model="form.notes"
+                      id="notes"
                       rows="4"
                       class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100"
-                      placeholder="Contract terms and conditions..."></textarea>
-            @error('form.terms_conditions') 
-                <span class="text-red-500 text-xs mt-1">{{ $message }}</span> 
+                      placeholder="Additional notes..."></textarea>
+            @error('form.notes')
+                <span class="text-red-500 text-xs mt-1">{{ $message }}</span>
             @enderror
         </div>
 

--- a/resources/views/livewire/partials/organization/contracts-tab.blade.php
+++ b/resources/views/livewire/partials/organization/contracts-tab.blade.php
@@ -41,12 +41,6 @@
                                         <x-heroicon-o-tag class="h-3 w-3" />
                                         {{ ucfirst($contract->type) }}
                                     </span>
-                                    @if($contract->contract_value)
-                                    <span class="flex items-center gap-1">
-                                        <x-heroicon-o-currency-dollar class="h-3 w-3" />
-                                        {{ $contract->currency }} {{ number_format($contract->contract_value, 0) }}
-                                    </span>
-                                    @endif
                                     @if($contract->end_date)
                                     <span class="flex items-center gap-1">
                                         <x-heroicon-o-calendar class="h-3 w-3" />

--- a/resources/views/livewire/view-organization.blade.php
+++ b/resources/views/livewire/view-organization.blade.php
@@ -10,21 +10,13 @@
                 <div class="hidden sm:block w-px h-6 bg-neutral-300 dark:bg-neutral-600"></div>
                 <div>
                     <h1 class="text-2xl sm:text-3xl font-bold text-neutral-800 dark:text-neutral-100">{{ $organization->name }}</h1>
-                    <p class="text-sm text-neutral-600 dark:text-neutral-400 mt-1">{{ $organization->company }}</p>
+                    <p class="text-sm text-neutral-600 dark:text-neutral-400 mt-1">{{ $organization->company ?? 'Not provided' }}</p>
                 </div>
             </div>
             
             <div class="flex items-center gap-2">
                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $organization->is_active ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300' : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300' }}">
                     {{ $organization->status_label }}
-                </span>
-                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                    @if($organization->subscription_status === 'active') bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300
-                    @elseif($organization->subscription_status === 'trial') bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300
-                    @elseif($organization->subscription_status === 'suspended') bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300
-                    @else bg-gray-100 text-gray-800 dark:bg-gray-900/40 dark:text-gray-300
-                    @endif">
-                    {{ $organization->subscription_status_label }}
                 </span>
             </div>
         </div>
@@ -91,18 +83,24 @@
                         </div>
                     @endforeach
 
-                    {{-- Subscription Status --}}
+                    {{-- Subscription Status & Active Toggle --}}
                     <div wire:key="subscription-status-{{ $organization->id }}">
                         <dt class="font-medium text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wide">Subscription</dt>
                         <dd class="mt-1 text-sm">
                             @if ($editMode)
-                                <select wire:model.defer="form.subscription_status"
-                                    class="w-full px-3 py-2 rounded-md bg-white/60 dark:bg-neutral-900/50 text-sm border border-neutral-300 dark:border-neutral-600 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all duration-200">
-                                    <option value="trial">Trial</option>
-                                    <option value="active">Active</option>
-                                    <option value="suspended">Suspended</option>
-                                    <option value="cancelled">Cancelled</option>
-                                </select>
+                                <div class="flex items-center gap-4">
+                                    <select wire:model.defer="form.subscription_status"
+                                        class="w-full px-3 py-2 rounded-md bg-white/60 dark:bg-neutral-900/50 text-sm border border-neutral-300 dark:border-neutral-600 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all duration-200">
+                                        <option value="trial">Trial</option>
+                                        <option value="active">Active</option>
+                                        <option value="suspended">Suspended</option>
+                                        <option value="cancelled">Cancelled</option>
+                                    </select>
+                                    <label class="inline-flex items-center">
+                                        <input type="checkbox" wire:model.defer="form.is_active" class="h-5 w-5 text-sky-600 focus:ring-sky-500 border-neutral-300 rounded">
+                                        <span class="ml-2">Active</span>
+                                    </label>
+                                </div>
                             @else
                                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
                                     @if($organization->subscription_status === 'active') bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300

--- a/resources/views/livewire/view-ticket.blade.php
+++ b/resources/views/livewire/view-ticket.blade.php
@@ -205,11 +205,6 @@
                                             {{ $this->activeContract->start_date->format('M d, Y') }} - 
                                             {{ $this->activeContract->end_date ? $this->activeContract->end_date->format('M d, Y') : 'Ongoing' }}
                                         </div>
-                                        @if($this->activeContract->contract_value)
-                                        <div class="text-xs text-neutral-600 dark:text-neutral-400">
-                                            Value: {{ $this->activeContract->currency }} {{ number_format($this->activeContract->contract_value, 2) }}
-                                        </div>
-                                        @endif
                                     </div>
                                 @else
                                     <div class="flex items-center gap-2">

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -113,10 +113,6 @@
                                 <span class="text-sm text-neutral-600 dark:text-neutral-400">{{ ucfirst($this->activeContract->type) }}</span>
                             </div>
                             <div class="flex justify-between">
-                                <span class="text-sm font-medium text-neutral-700 dark:text-neutral-300">Value:</span>
-                                <span class="text-sm text-neutral-600 dark:text-neutral-400">{{ $this->activeContract->currency }} {{ number_format($this->activeContract->contract_value, 2) }}</span>
-                            </div>
-                            <div class="flex justify-between">
                                 <span class="text-sm font-medium text-neutral-700 dark:text-neutral-300">Period:</span>
                                 <span class="text-sm text-neutral-600 dark:text-neutral-400">{{ $this->activeContract->start_date->format('M d, Y') }} - {{ $this->activeContract->end_date->format('M d, Y') }}</span>
                             </div>


### PR DESCRIPTION
## Summary
- remove contract value and currency from organization contracts and add Oracle CSI fields
- clean sample data and contract views/forms to use notes instead of terms and show optional Oracle info
- make organization company and TIN optional with aligned active toggle and simplified status badge

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689c74823e688332b09ad7e6149854bf