### PR TITLE
feat: contract-first hardware wizard

### DIFF
--- a/app/Livewire/HardwareContractSelector.php
+++ b/app/Livewire/HardwareContractSelector.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\OrganizationContract;
+use Livewire\Component;
+
+class HardwareContractSelector extends Component
+{
+    public int $organizationId;
+    public ?int $selected = null;
+
+    public function mount(int $organizationId): void
+    {
+        $this->organizationId = $organizationId;
+    }
+
+    public function selectContract(): void
+    {
+        if ($this->selected) {
+            $this->dispatch('contractSelected', $this->selected);
+        }
+    }
+
+    public function render()
+    {
+        $contracts = OrganizationContract::where('organization_id', $this->organizationId)->get();
+        return view('livewire.hardware-contract-selector', [
+            'contracts' => $contracts,
+        ]);
+    }
+}

--- a/app/Livewire/HardwareFormSimple.php
+++ b/app/Livewire/HardwareFormSimple.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\HardwareType;
+use App\Models\OrganizationHardware;
+use Livewire\Component;
+
+class HardwareFormSimple extends Component
+{
+    public int $organizationId;
+    public int $contractId;
+
+    public array $form = [
+        'hardware_type_id' => '',
+        'model' => '',
+        'brand' => '',
+        'quantity' => 1,
+        'serial_required' => false,
+        'remarks' => '',
+    ];
+
+    protected $rules = [
+        'form.hardware_type_id' => 'required|exists:hardware_types,id',
+        'form.model' => 'nullable|string|max:255',
+        'form.brand' => 'nullable|string|max:255',
+        'form.quantity' => 'required|integer|min:1',
+        'form.serial_required' => 'boolean',
+        'form.remarks' => 'nullable|string',
+    ];
+
+    public function mount(int $organizationId, int $contractId): void
+    {
+        $this->organizationId = $organizationId;
+        $this->contractId = $contractId;
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+        $data = $this->form;
+        $data['organization_id'] = $this->organizationId;
+        $data['contract_id'] = $this->contractId;
+        $hardware = OrganizationHardware::create($data);
+        $this->dispatch('hardwareCreated', $hardware->id, $hardware->serial_required, $hardware->quantity);
+    }
+
+    public function render()
+    {
+        return view('livewire.hardware-form-simple', [
+            'types' => HardwareType::all(),
+        ]);
+    }
+}

--- a/app/Livewire/HardwareSerialManager.php
+++ b/app/Livewire/HardwareSerialManager.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\HardwareSerial;
+use App\Models\OrganizationHardware;
+use Livewire\Component;
+
+class HardwareSerialManager extends Component
+{
+    public int $hardwareId;
+    public int $targetCount;
+    public string $serialInput = '';
+    public $serials;
+
+    protected $rules = [
+        'serialInput' => 'required|string|max:255',
+    ];
+
+    public function mount(int $hardwareId, int $targetCount): void
+    {
+        $this->hardwareId = $hardwareId;
+        $this->targetCount = $targetCount;
+        $this->loadSerials();
+    }
+
+    public function loadSerials(): void
+    {
+        $this->serials = HardwareSerial::where('organization_hardware_id', $this->hardwareId)->get();
+    }
+
+    public function addSerial(): void
+    {
+        $this->serialInput = trim($this->serialInput);
+        $this->validate();
+
+        if ($this->serials->count() >= $this->targetCount) {
+            return;
+        }
+
+        if ($this->serials->contains('serial', $this->serialInput)) {
+            return;
+        }
+
+        HardwareSerial::create([
+            'organization_hardware_id' => $this->hardwareId,
+            'serial' => $this->serialInput,
+        ]);
+
+        $this->serialInput = '';
+        $this->loadSerials();
+
+        if ($this->serials->count() >= $this->targetCount) {
+            $this->dispatch('serialsComplete');
+        }
+    }
+
+    public function removeSerial(int $id): void
+    {
+        HardwareSerial::where('organization_hardware_id', $this->hardwareId)->where('id', $id)->delete();
+        $this->loadSerials();
+    }
+
+    public function render()
+    {
+        $progress = $this->serials->count();
+        return view('livewire.hardware-serial-manager', [
+            'progress' => $progress,
+        ]);
+    }
+}

--- a/app/Livewire/OrganizationHardwareWizard.php
+++ b/app/Livewire/OrganizationHardwareWizard.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Organization;
+use Livewire\Component;
+
+/**
+ * Parent shell for contract-first hardware creation.
+ * Maps existing hardware flow files:
+ * - app/Livewire/ManageHardware.php
+ * - app/Livewire/OrganizationHardwareForm.php
+ * - resources/views/livewire/manage-hardware.blade.php
+ * - resources/views/livewire/organization-hardware-form.blade.php
+ * - resources/views/livewire/partials/organization/hardware.blade.php
+ * - resources/views/livewire/partials/organization/hardware-tab.blade.php
+ * - routes/web.php (hardware.manage route)
+ * - app/Http/Controllers/OrganizationHardwareController.php
+ * - no dedicated policy found for OrganizationHardware
+ */
+class OrganizationHardwareWizard extends Component
+{
+    public Organization $organization;
+    public string $step = 'contract';
+    public ?int $contractId = null;
+    public ?int $hardwareId = null;
+    public bool $serialRequired = false;
+    public int $quantity = 0;
+
+    protected $listeners = [
+        'contractSelected' => 'onContractSelected',
+        'hardwareCreated' => 'onHardwareCreated',
+        'serialsComplete' => 'onSerialsComplete',
+    ];
+
+    public function mount(Organization $organization): void
+    {
+        $this->organization = $organization;
+    }
+
+    public function onContractSelected(int $contractId): void
+    {
+        $this->contractId = $contractId;
+        $this->step = 'hardware';
+    }
+
+    public function onHardwareCreated(int $hardwareId, bool $serialRequired, int $quantity): void
+    {
+        $this->hardwareId = $hardwareId;
+        $this->serialRequired = $serialRequired;
+        $this->quantity = $quantity;
+        $this->step = $serialRequired ? 'serials' : 'done';
+    }
+
+    public function onSerialsComplete(): void
+    {
+        $this->step = 'done';
+    }
+
+    public function render()
+    {
+        return view('livewire.organization-hardware-wizard');
+    }
+}

--- a/app/Models/HardwareSerial.php
+++ b/app/Models/HardwareSerial.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class HardwareSerial extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['organization_hardware_id', 'serial', 'notes'];
+
+    public function hardware()
+    {
+        return $this->belongsTo(OrganizationHardware::class, 'organization_hardware_id');
+    }
+}

--- a/app/Models/HardwareType.php
+++ b/app/Models/HardwareType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class HardwareType extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+}

--- a/app/Models/OrganizationHardware.php
+++ b/app/Models/OrganizationHardware.php
@@ -13,12 +13,9 @@ class OrganizationHardware extends Model
     protected $table = 'organization_hardware';
 
     protected $fillable = [
+        // Legacy fields (deprecated in UI)
         'asset_tag',
-        'organization_id',
-        'contract_id',
         'hardware_type',
-        'brand',
-        'model',
         'serial_number',
         'specifications',
         'purchase_date',
@@ -27,9 +24,18 @@ class OrganizationHardware extends Model
         'warranty_expiration',
         'status',
         'location',
-        'remarks',
         'last_maintenance',
         'next_maintenance',
+
+        // New simplified contract-first fields
+        'organization_id',
+        'contract_id',
+        'hardware_type_id',
+        'brand',
+        'model',
+        'quantity',
+        'serial_required',
+        'remarks',
     ];
 
     protected $casts = [
@@ -40,6 +46,7 @@ class OrganizationHardware extends Model
         'custom_fields' => 'array',
         'last_maintenance' => 'datetime',
         'next_maintenance' => 'datetime',
+        'serial_required' => 'boolean',
     ];
 
     public function organization()
@@ -50,5 +57,15 @@ class OrganizationHardware extends Model
     public function contract()
     {
         return $this->belongsTo(OrganizationContract::class, 'contract_id');
+    }
+
+    public function type()
+    {
+        return $this->belongsTo(HardwareType::class, 'hardware_type_id');
+    }
+
+    public function serials()
+    {
+        return $this->hasMany(HardwareSerial::class, 'organization_hardware_id');
     }
 }

--- a/database/migrations/2025_01_01_000011_create_hardware_types_table.php
+++ b/database/migrations/2025_01_01_000011_create_hardware_types_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('hardware_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hardware_types');
+    }
+};

--- a/database/migrations/2025_01_01_000012_add_contract_first_fields_to_organization_hardware.php
+++ b/database/migrations/2025_01_01_000012_add_contract_first_fields_to_organization_hardware.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organization_hardware', function (Blueprint $table) {
+            $table->foreignId('hardware_type_id')->nullable()->after('contract_id')->constrained('hardware_types');
+            $table->integer('quantity')->default(1)->after('model');
+            $table->boolean('serial_required')->default(false)->after('quantity');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organization_hardware', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('hardware_type_id');
+            $table->dropColumn(['quantity','serial_required']);
+        });
+    }
+};

--- a/database/migrations/2025_01_01_000013_create_hardware_serials_table.php
+++ b/database/migrations/2025_01_01_000013_create_hardware_serials_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('hardware_serials', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_hardware_id')->constrained('organization_hardware')->onDelete('cascade');
+            $table->string('serial');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->unique(['organization_hardware_id', 'serial']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hardware_serials');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use Database\Seeders\HardwareTypesSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -20,6 +21,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RolePermissionSeeder::class,     // Clears all data, creates permissions and roles
             BasicDataSeeder::class,          // Creates organization, department groups, and departments
+            HardwareTypesSeeder::class,      // Seeds baseline hardware types
             UserSeeder::class,              // Creates users with proper assignments
             ScheduleEventTypeSeeder::class,  // Creates schedule event types
             DashboardWidgetSeeder::class,    // Creates widget catalog

--- a/database/seeders/HardwareTypesSeeder.php
+++ b/database/seeders/HardwareTypesSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\HardwareType;
+
+class HardwareTypesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $types = ['Desktop', 'Laptop', 'Server', 'Printer'];
+        foreach ($types as $name) {
+            HardwareType::firstOrCreate(['name' => $name]);
+        }
+    }
+}

--- a/resources/views/livewire/hardware-contract-selector.blade.php
+++ b/resources/views/livewire/hardware-contract-selector.blade.php
@@ -1,0 +1,12 @@
+<div class="space-y-4 p-4 border border-neutral-200 dark:border-neutral-200/20 rounded">
+    <h2 class="text-lg font-semibold text-neutral-800 dark:text-neutral-100">Select Hardware Contract</h2>
+    <div class="flex space-x-2 items-end">
+        <select wire:model="selected" class="flex-1 px-3 py-2 border rounded bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
+            <option value="">-- Choose Contract --</option>
+            @foreach($contracts as $contract)
+                <option value="{{ $contract->id }}">{{ $contract->title ?? ('Contract #' . $contract->id) }}</option>
+            @endforeach
+        </select>
+        <button wire:click="selectContract" class="px-4 py-2 bg-sky-600 text-white rounded">Next</button>
+    </div>
+</div>

--- a/resources/views/livewire/hardware-form-simple.blade.php
+++ b/resources/views/livewire/hardware-form-simple.blade.php
@@ -1,0 +1,46 @@
+<div class="space-y-4 p-4 border border-neutral-200 dark:border-neutral-200/20 rounded">
+    <h2 class="text-lg font-semibold text-neutral-800 dark:text-neutral-100">Hardware Details</h2>
+    <form wire:submit.prevent="save" class="space-y-4">
+        <div>
+            <label class="block text-sm mb-1 text-neutral-700 dark:text-neutral-300">Hardware Type</label>
+            <select wire:model="form.hardware_type_id" class="w-full px-3 py-2 border rounded bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100">
+                <option value="">-- Select Type --</option>
+                @foreach($types as $type)
+                    <option value="{{ $type->id }}">{{ $type->name }}</option>
+                @endforeach
+            </select>
+            @error('form.hardware_type_id')<span class="text-red-500 text-xs">{{ $message }}</span>@enderror
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="block text-sm mb-1 text-neutral-700 dark:text-neutral-300">Model</label>
+                <input type="text" wire:model="form.model" class="w-full px-3 py-2 border rounded bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100" />
+                @error('form.model')<span class="text-red-500 text-xs">{{ $message }}</span>@enderror
+            </div>
+            <div>
+                <label class="block text-sm mb-1 text-neutral-700 dark:text-neutral-300">Brand</label>
+                <input type="text" wire:model="form.brand" class="w-full px-3 py-2 border rounded bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100" />
+                @error('form.brand')<span class="text-red-500 text-xs">{{ $message }}</span>@enderror
+            </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="block text-sm mb-1 text-neutral-700 dark:text-neutral-300">Quantity</label>
+                <input type="number" min="1" wire:model="form.quantity" class="w-full px-3 py-2 border rounded bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100" />
+                @error('form.quantity')<span class="text-red-500 text-xs">{{ $message }}</span>@enderror
+            </div>
+            <div class="flex items-center space-x-2 pt-6">
+                <input type="checkbox" wire:model="form.serial_required" id="serial_required" class="h-4 w-4" />
+                <label for="serial_required" class="text-sm text-neutral-700 dark:text-neutral-300">Serials Required</label>
+            </div>
+        </div>
+        <div>
+            <label class="block text-sm mb-1 text-neutral-700 dark:text-neutral-300">Remarks</label>
+            <textarea wire:model="form.remarks" class="w-full px-3 py-2 border rounded bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100"></textarea>
+            @error('form.remarks')<span class="text-red-500 text-xs">{{ $message }}</span>@enderror
+        </div>
+        <div class="flex justify-end">
+            <button type="submit" class="px-4 py-2 bg-sky-600 text-white rounded">Save</button>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/hardware-serial-manager.blade.php
+++ b/resources/views/livewire/hardware-serial-manager.blade.php
@@ -1,0 +1,16 @@
+<div class="space-y-4 p-4 border border-neutral-200 dark:border-neutral-200/20 rounded">
+    <h2 class="text-lg font-semibold text-neutral-800 dark:text-neutral-100">Serial Numbers</h2>
+    <div class="flex space-x-2">
+        <input type="text" wire:model="serialInput" wire:keydown.enter.prevent="addSerial" class="flex-1 px-3 py-2 border rounded bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100" placeholder="Enter serial" />
+        <button wire:click="addSerial" class="px-4 py-2 bg-sky-600 text-white rounded">Add</button>
+    </div>
+    <div class="text-sm text-neutral-700 dark:text-neutral-300">{{ $progress }} / {{ $targetCount }} serials captured</div>
+    <ul class="space-y-1 max-h-64 overflow-y-auto">
+        @foreach($serials as $s)
+            <li class="flex justify-between items-center border-b border-neutral-200 dark:border-neutral-700 py-1">
+                <span>{{ $s->serial }}</span>
+                <button wire:click="removeSerial({{ $s->id }})" class="text-red-600">&times;</button>
+            </li>
+        @endforeach
+    </ul>
+</div>

--- a/resources/views/livewire/organization-hardware-wizard.blade.php
+++ b/resources/views/livewire/organization-hardware-wizard.blade.php
@@ -1,0 +1,11 @@
+<div class="space-y-4">
+    @if($step === 'contract')
+        <livewire:hardware-contract-selector :organization-id="$organization->id" />
+    @elseif($step === 'hardware' && $contractId)
+        <livewire:hardware-form-simple :organization-id="$organization->id" :contract-id="$contractId" />
+    @elseif($step === 'serials' && $hardwareId)
+        <livewire:hardware-serial-manager :hardware-id="$hardwareId" :target-count="$quantity" />
+    @else
+        <div class="p-4 text-sm text-neutral-700 dark:text-neutral-300">Hardware entry complete.</div>
+    @endif
+</div>

--- a/resources/views/livewire/partials/organization/hardware.blade.php
+++ b/resources/views/livewire/partials/organization/hardware.blade.php
@@ -1,22 +1,19 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
     @forelse($organization->hardware as $hw)
-        <div
-            class="bg-white/10 backdrop-blur-md border border-neutral-200 dark:border-neutral-200/20 rounded-lg p-4 shadow-sm dark:shadow-neutral-200/10 transition transform hover:-translate-y-1 space-y-1">
-
+        <div class="bg-white/10 backdrop-blur-md border border-neutral-200 dark:border-neutral-200/20 rounded-lg p-4 shadow-sm dark:shadow-neutral-200/10 transition transform hover:-translate-y-1 space-y-1">
             <div class="flex justify-between items-start">
                 <div>
                     <div class="text-base font-semibold text-neutral-800 dark:text-neutral-100 mb-1">
-                        {{ $hw->hardware_type }} / {{ $hw->hardware_model }}
-                        @if ($hw->is_active)
-                            <span
-                                class="ml-2 text-xs font-medium px-2 py-0.5 rounded bg-green-200 text-green-900">
-                                Active
-                            </span>
-                        @endif
+                        {{ $hw->type?->name }} / {{ $hw->model }}
                     </div>
                     <div class="text-xs text-neutral-500 dark:text-neutral-400">
-                        SN: {{ $hw->serial_number }} • Exp: {{ $hw->warranty_expiration->format('d-m-Y') }}
+                        Brand: {{ $hw->brand }} • Qty: {{ $hw->quantity }}
                     </div>
+                    @if($hw->serial_required)
+                        <div class="text-xs text-neutral-500 dark:text-neutral-400">
+                            Serials: {{ $hw->serials->count() }} / {{ $hw->quantity }}
+                        </div>
+                    @endif
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Livewire\ViewOrganization;
 use App\Livewire\ManageContracts;
 use App\Livewire\ManageHardware;
 use App\Livewire\ManageUsers;
+use App\Livewire\OrganizationHardwareWizard;
 use App\Livewire\CreateTicket;
 use App\Livewire\ManageTickets;
 use App\Livewire\ViewTicket;
@@ -78,6 +79,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/hardware', function() { return redirect()->route('organizations.index'); });
     Route::get('/hardware/{hardware}', function() { return redirect()->route('organizations.index'); })->name('hardware.show');
     Route::get('/hardware/manage/{organization}', ManageHardware::class)->name('hardware.manage');
+    Route::get('/organizations/{organization}/hardware/create', OrganizationHardwareWizard::class)->name('organizations.hardware.create');
 
     // User Routes (Organization-specific)
     Route::get('/users', function() { return redirect()->route('organizations.index'); });


### PR DESCRIPTION
## Summary
- add hardware types and serials tables with seeder
- update organization hardware model for quantity and serial tracking
- introduce contract-first hardware creation wizard with serial capture

## Testing
- `php -l app/Livewire/OrganizationHardwareWizard.php app/Livewire/HardwareContractSelector.php app/Livewire/HardwareFormSimple.php app/Livewire/HardwareSerialManager.php app/Models/HardwareType.php app/Models/HardwareSerial.php app/Models/OrganizationHardware.php database/seeders/HardwareTypesSeeder.php database/seeders/DatabaseSeeder.php routes/web.php`
- `composer install` (fails: GitHub OAuth token required)

------
https://chatgpt.com/codex/tasks/task_e_689c9704bdc08332a55bc4fb9fde2a5d