### PR TITLE
feat: add ticket hardware linking skeleton

### DIFF
--- a/app/Livewire/Tickets/LinkHardwareModal.php
+++ b/app/Livewire/Tickets/LinkHardwareModal.php
@@ -18,10 +18,17 @@ class LinkHardwareModal extends Component
     public function mount(Ticket $ticket): void
     {
         $this->ticket = $ticket;
+        $this->authorize('view', $this->ticket);
     }
 
     public function toggle(): void
     {
+        $this->authorize('update', $this->ticket);
+
+        if ($this->ticket->isClosed()) {
+            return;
+        }
+
         $this->show = ! $this->show;
     }
 

--- a/app/Livewire/Tickets/LinkHardwareModal.php
+++ b/app/Livewire/Tickets/LinkHardwareModal.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Livewire\Tickets;
+
+use App\Models\Ticket;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class LinkHardwareModal extends Component
+{
+    use AuthorizesRequests;
+
+    public Ticket $ticket;
+    public bool $show = false;
+
+    protected $listeners = ['link-hardware:toggle' => 'toggle'];
+
+    public function mount(Ticket $ticket): void
+    {
+        $this->ticket = $ticket;
+    }
+
+    public function toggle(): void
+    {
+        $this->show = ! $this->show;
+    }
+
+    public function render()
+    {
+        return view('livewire.tickets.link-hardware-modal');
+    }
+}
+

--- a/app/Livewire/Tickets/QuickActions.php
+++ b/app/Livewire/Tickets/QuickActions.php
@@ -6,6 +6,7 @@ use App\Models\Ticket;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 use App\Livewire\Tickets\SplitTicketModal;
+use App\Livewire\Tickets\LinkHardwareModal;
 
 class QuickActions extends Component
 {
@@ -114,6 +115,12 @@ class QuickActions extends Component
     public function showSplit(): void
     {
         $this->dispatch('split:toggle')->to(SplitTicketModal::class);
+    }
+
+    public function linkHardware(): void
+    {
+        $this->authorize('update', $this->ticket);
+        $this->dispatch('link-hardware:toggle')->to(LinkHardwareModal::class);
     }
 
     public function render()

--- a/app/Models/HardwareSerial.php
+++ b/app/Models/HardwareSerial.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+use App\Models\Ticket;
 
 class HardwareSerial extends Model
 {
@@ -14,5 +17,11 @@ class HardwareSerial extends Model
     public function hardware()
     {
         return $this->belongsTo(OrganizationHardware::class, 'organization_hardware_id');
+    }
+
+    public function tickets(): BelongsToMany
+    {
+        return $this->belongsToMany(Ticket::class, 'ticket_hardware_serial')
+            ->withTimestamps();
     }
 }

--- a/app/Models/OrganizationHardware.php
+++ b/app/Models/OrganizationHardware.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+use App\Models\Ticket;
 
 class OrganizationHardware extends Model
 {
@@ -58,6 +61,13 @@ class OrganizationHardware extends Model
     public function serials()
     {
         return $this->hasMany(HardwareSerial::class, 'organization_hardware_id');
+    }
+
+    public function tickets(): BelongsToMany
+    {
+        return $this->belongsToMany(Ticket::class, 'ticket_organization_hardware')
+            ->withPivot('maintenance_note')
+            ->withTimestamps();
     }
 
     protected static function boot()

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -7,11 +7,14 @@ use App\Models\TicketStatus as TicketStatusModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 use App\Models\User;
+use App\Models\OrganizationHardware;
+use App\Models\HardwareSerial;
 
 /**
  * App\Models\Ticket
@@ -176,6 +179,21 @@ class Ticket extends Model
     public function attachments(): HasManyThrough
     {
         return $this->hasManyThrough(TicketMessageAttachment::class, TicketMessage::class);
+    }
+
+    // Linked hardware at hardware level
+    public function hardware(): BelongsToMany
+    {
+        return $this->belongsToMany(OrganizationHardware::class, 'ticket_organization_hardware')
+            ->withPivot('maintenance_note')
+            ->withTimestamps();
+    }
+
+    // Linked hardware serials
+    public function serials(): BelongsToMany
+    {
+        return $this->belongsToMany(HardwareSerial::class, 'ticket_hardware_serial')
+            ->withTimestamps();
     }
 
     // Department Group (via Department) - using accessor for simplicity

--- a/database/migrations/2025_08_27_101000_create_ticket_organization_hardware_table.php
+++ b/database/migrations/2025_08_27_101000_create_ticket_organization_hardware_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_organization_hardware', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ticket_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('organization_hardware_id')->constrained('organization_hardware')->cascadeOnDelete();
+            $table->text('maintenance_note')->nullable();
+            $table->timestamps();
+
+            $table->unique(['ticket_id', 'organization_hardware_id']);
+            $table->index('organization_hardware_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_organization_hardware');
+    }
+};
+

--- a/database/migrations/2025_08_27_101010_create_ticket_hardware_serial_table.php
+++ b/database/migrations/2025_08_27_101010_create_ticket_hardware_serial_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_hardware_serial', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ticket_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('hardware_serial_id')->constrained('hardware_serials')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['ticket_id', 'hardware_serial_id']);
+            $table->index('hardware_serial_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_hardware_serial');
+    }
+};
+

--- a/resources/views/livewire/tickets/link-hardware-modal.blade.php
+++ b/resources/views/livewire/tickets/link-hardware-modal.blade.php
@@ -1,0 +1,9 @@
+<div>
+    @if($show)
+        <div class="p-4 bg-white dark:bg-neutral-800 rounded-lg shadow">
+            <p class="text-sm text-neutral-700 dark:text-neutral-300">
+                Hardware linking interface goes here.
+            </p>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/tickets/quick-actions.blade.php
+++ b/resources/views/livewire/tickets/quick-actions.blade.php
@@ -61,8 +61,8 @@
         
         @can('assign', $ticket)
             @if($ticket->owner_id !== auth()->id())
-                <button wire:click="assignToMe" wire:loading.attr="disabled" 
-                        class="group relative flex items-center p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/30 rounded-md transition-all duration-300 ease-in-out overflow-hidden" 
+                <button wire:click="assignToMe" wire:loading.attr="disabled"
+                        class="group relative flex items-center p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/30 rounded-md transition-all duration-300 ease-in-out overflow-hidden"
                         aria-label="Assign to Me" title="Assign to Me">
                     <span class="text-sm font-medium w-0 opacity-0 group-hover:w-auto group-hover:opacity-100 group-hover:mr-2 transition-all duration-300 ease-in-out whitespace-nowrap overflow-hidden">
                         Assign to Me
@@ -71,10 +71,21 @@
                 </button>
             @endif
         @endcan
-        
+
+        @can('update', $ticket)
+            <button wire:click="linkHardware" wire:loading.attr="disabled"
+                    class="group relative flex items-center p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-md transition-all duration-300 ease-in-out overflow-hidden"
+                    aria-label="Link Hardware" title="Link Hardware">
+                <span class="text-sm font-medium w-0 opacity-0 group-hover:w-auto group-hover:opacity-100 group-hover:mr-2 transition-all duration-300 ease-in-out whitespace-nowrap overflow-hidden">
+                    Link Hardware
+                </span>
+                <x-heroicon-o-link class="h-5 w-5 flex-shrink-0 transition-transform duration-300 group-hover:scale-110" />
+            </button>
+        @endcan
+
         @can('split', $ticket)
-            <button wire:click="showSplit" wire:loading.attr="disabled" 
-                    class="group relative flex items-center p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded-md transition-all duration-300 ease-in-out overflow-hidden" 
+            <button wire:click="showSplit" wire:loading.attr="disabled"
+                    class="group relative flex items-center p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 rounded-md transition-all duration-300 ease-in-out overflow-hidden"
                     aria-label="Split Ticket" title="Split Ticket">
                 <span class="text-sm font-medium w-0 opacity-0 group-hover:w-auto group-hover:opacity-100 group-hover:mr-2 transition-all duration-300 ease-in-out whitespace-nowrap overflow-hidden">
                     Split

--- a/resources/views/livewire/tickets/view-ticket.blade.php
+++ b/resources/views/livewire/tickets/view-ticket.blade.php
@@ -39,6 +39,7 @@
     <livewire:tickets.split-ticket-modal :ticket="$ticket" />
     <livewire:tickets.merge-tickets-modal :ticket="$ticket" />
     <livewire:tickets.attachment-preview-modal wire:ref="attachmentModal" />
+    <livewire:tickets.link-hardware-modal :ticket="$ticket" />
 </div>
 
 <script>

--- a/resources/views/livewire/tickets/view-ticket.blade.php
+++ b/resources/views/livewire/tickets/view-ticket.blade.php
@@ -39,7 +39,9 @@
     <livewire:tickets.split-ticket-modal :ticket="$ticket" />
     <livewire:tickets.merge-tickets-modal :ticket="$ticket" />
     <livewire:tickets.attachment-preview-modal wire:ref="attachmentModal" />
-    <livewire:tickets.link-hardware-modal :ticket="$ticket" />
+    @can('update', $ticket)
+        <livewire:tickets.link-hardware-modal :ticket="$ticket" />
+    @endcan
 </div>
 
 <script>


### PR DESCRIPTION
## Summary
- scaffold pivot tables for ticket-to-hardware and hardware-serial links
- add model relationships and initial Livewire modal/button for hardware linking

## Testing
- `composer install` *(fails: GitHub token required)*


------
https://chatgpt.com/codex/tasks/task_e_68b0958753e8833286ccfa8d220e5757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Link Hardware” action on tickets for authorized users.
  - Introduced a modal to link organization hardware and serial numbers to a ticket.
  - Supports adding an optional maintenance note when linking hardware.
  - Associations are preserved with timestamps for better traceability.
  - New button appears in Quick Actions; modal can be toggled within the ticket view.

- UI
  - Ticket view now includes the hardware-linking modal component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->